### PR TITLE
Removed unreachable banning code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In order to get into the queue, a web client will submit a web form. Typically, 
 }
 ```
 
-If the queue is open, the requester's email will get into the queue. If the queue is close, the requester's email will be added to a special list of banned emails, since when using the web client, it should not be possible to fill out the form before the queue is open.
+If the queue is open, the requester's email will get into the queue. If the queue is closed, the request is ignored, as it should not be possible to fill out the form before the queue is open.
 
 
 > **NOTICE:** the `POST /register` route is a dynamically changeable route defined by the `REGISTER_ROUTE` env variable. If not defined, the route will default to `/register`. Email field name is also configurable by the `USERS_EMAIL_PARAM` env variable.

--- a/midburn_queue.rb
+++ b/midburn_queue.rb
@@ -74,7 +74,6 @@ class MidburnQueue < Sinatra::Base
     if queue_is_open?
       Resque.enqueue(TicketsQueue, order_json)
     else
-      Resque.enqueue(BannedOrder, order_json)
       halt(403)
     end
   end

--- a/worker.rb
+++ b/worker.rb
@@ -4,12 +4,6 @@ class TicketsQueue
   end
 end
 
-class BannedOrder
-  @queue = :banned
-  def self.perform(word)
-  end
-end
-
 def process_order(order)
   # process order
   puts "got: #{order}"


### PR DESCRIPTION
As discussed in #21 , @omerpines and @eladg agree that:
1. "We don't use the ban at all"
2. "The attacker cannot know the route until we open the queue."

Therefore, this code is unreachable.
If It was reachable - this could be a security issue, as an attacker could add other people to the banned list.
